### PR TITLE
[IS-1292] add workflow snapcraft release

### DIFF
--- a/.github/workflows/release_packages.yaml
+++ b/.github/workflows/release_packages.yaml
@@ -4,19 +4,19 @@ on:
       loopchain:
         description: 'loopchain tag'
         required: true
-        default: '2.7.0rc1'
+        default: '2.7.0'
       iconrpcserver:
         description: 'iconrpcserver tag'
         required: true
-        default: '1.6.0rc1'
+        default: '1.6.0'
       iconservice:
         description: 'iconservice tag'
         required: true
-        default: '1.8.0rc1'
+        default: '1.8.0'
       rewardcalculator:
         description: 'rewardcalculator tag'
         required: true
-        default: '1.2.2'
+        default: '1.2.3'
       release_tag:
         description: 'github release tag'
         required: true
@@ -90,8 +90,8 @@ jobs:
       - name: Upload release asset
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.RELEASE_TAG }} # ${{ github.ref }}
+          repo_token: ${{ secrets.RELEASE_SECRET }}
+          tag: ${{ env.RELEASE_TAG }}
           file: ${{ format('{0}/*', env.ASSETS_DIR) }}
           file_glob: true
           release_name: Release ${{ env.RELEASE_TAG }}

--- a/.github/workflows/snap_release.yaml
+++ b/.github/workflows/snap_release.yaml
@@ -47,21 +47,15 @@ jobs:
           ls -al ./$ASSETS_DIR
           echo "-------"
           echo "${{ env.PACKAGE_INFO_BODY }}"
-      - name: upload artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
-      - name: Upload release
+      - name: Publish to snap store
         if: ${{ false }}
-        uses: svenstaro/upload-release-action@v2
+        uses: snapcore/action-publish@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.RELEASE_TAG }} # ${{ github.ref }}
-          file: ${{ format('{0}/*', env.ASSETS_DIR) }}
-          file_glob: true
-          release_name: Release ${{ env.RELEASE_TAG }}
-          # prerelease: true
-          overwrite: true
-          body: |
-            ${{ env.PACKAGE_INFO_BODY }}
+          store_login: ${{ secrets.STORE_LOGIN }}
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: ${{ format('edge/{0}', env.RELEASE_TAG) }}

--- a/.github/workflows/snap_release.yaml
+++ b/.github/workflows/snap_release.yaml
@@ -1,59 +1,47 @@
 on:
+  release:
+    types:
+      - prereleased
+      - released
   workflow_dispatch:
     inputs:
-      loopchain:
-        description: 'loopchain tag'
+      upload_artifact:
+        description: 'upload artifact'
         required: true
-        default: '2.7.0'
-      iconrpcserver:
-        description: 'iconrpcserver tag'
-        required: true
-        default: '1.6.0'
-      iconservice:
-        description: 'iconservice tag'
-        required: true
-        default: '1.8.0'
-      rewardcalculator:
-        description: 'rewardcalculator tag'
-        required: true
-        default: '1.2.2'
-      release_tag:
-        description: 'snap release tag'
-        required: true
-        default: '2020.11'
+        default: 'yes'
 jobs:
   release:
     runs-on: ubuntu-latest
     env:
-      RC_BRANCH: ${{ github.event.inputs.rewardcalculator }}
-      RELEASE_TAG: ${{ github.event.inputs.release_tag }}
-      DEBUG: false
+      UPLOAD_ARTIFACT: ${{ github.event.inputs.upload_artifact }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      DEBUG: ${{ true }}
     steps:
       - name: Checkout release
         uses: actions/checkout@v2
-      - name: Workflow check
-        if : ${{ startsWith(env.DEBUG, 'true') }}
+      - name: Check environment variables
+        if : ${{ env.DEBUG }}
         run: |
           echo $PWD
-          ls -al
+          echo "upload artifact: ($UPLOAD_ARTIFACT)"
+          echo "release tag: ($RELEASE_TAG)"
+          echo "deubg: ($DEBUG)"
+          echo "release tag empty: (${{ env.RELEASE_TAG == '' }})"
       - name: Build snapcraft
         id: snapcraft
         uses: snapcore/action-build@v1
       - name: Check build result
-        if: ${{ startsWith(env.DEBUG, 'true') }}
+        if: ${{ env.DEBUG }}
         run: |
-          echo "github_tag: $RELEASE_TAG"
-          ls -al ./$BUILD_DIR
-          ls -al ./$ASSETS_DIR
-          echo "-------"
-          echo "${{ env.PACKAGE_INFO_BODY }}"
+          ls -al ${{ steps.snapcraft.outputs.snap }}
       - name: Upload artifact
+        if: ${{ env.UPLOAD_ARTIFACT == 'yes' }}
         uses: actions/upload-artifact@v2
         with:
-          name: snap
+          name: loopchain_snap
           path: ${{ steps.snapcraft.outputs.snap }}
       - name: Publish to snap store
-        if: ${{ false }}
+        if: ${{ success() && env.RELEASE_TAG != '' }}
         uses: snapcore/action-publish@v1
         with:
           store_login: ${{ secrets.STORE_LOGIN }}

--- a/.github/workflows/snap_release.yaml
+++ b/.github/workflows/snap_release.yaml
@@ -37,6 +37,7 @@ jobs:
           echo $PWD
           ls -al
       - name: Build snapcraft
+        id: snapcraft
         uses: snapcore/action-build@v1
       - name: Check build result
         if: ${{ startsWith(env.DEBUG, 'true') }}
@@ -46,7 +47,12 @@ jobs:
           ls -al ./$ASSETS_DIR
           echo "-------"
           echo "${{ env.PACKAGE_INFO_BODY }}"
-      - name: Upload release asset
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+      - name: Upload release
         if: ${{ false }}
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/snap_release.yaml
+++ b/.github/workflows/snap_release.yaml
@@ -1,0 +1,61 @@
+on:
+  workflow_dispatch:
+    inputs:
+      loopchain:
+        description: 'loopchain tag'
+        required: true
+        default: '2.7.0'
+      iconrpcserver:
+        description: 'iconrpcserver tag'
+        required: true
+        default: '1.6.0'
+      iconservice:
+        description: 'iconservice tag'
+        required: true
+        default: '1.8.0'
+      rewardcalculator:
+        description: 'rewardcalculator tag'
+        required: true
+        default: '1.2.2'
+      release_tag:
+        description: 'snap release tag'
+        required: true
+        default: '2020.11'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      RC_BRANCH: ${{ github.event.inputs.rewardcalculator }}
+      RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+      DEBUG: false
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v2
+      - name: Workflow check
+        if : ${{ startsWith(env.DEBUG, 'true') }}
+        run: |
+          echo $PWD
+          ls -al
+      - name: Build snapcraft
+        uses: snapcore/action-build@v1
+      - name: Check build result
+        if: ${{ startsWith(env.DEBUG, 'true') }}
+        run: |
+          echo "github_tag: $RELEASE_TAG"
+          ls -al ./$BUILD_DIR
+          ls -al ./$ASSETS_DIR
+          echo "-------"
+          echo "${{ env.PACKAGE_INFO_BODY }}"
+      - name: Upload release asset
+        if: ${{ false }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.RELEASE_TAG }} # ${{ github.ref }}
+          file: ${{ format('{0}/*', env.ASSETS_DIR) }}
+          file_glob: true
+          release_name: Release ${{ env.RELEASE_TAG }}
+          # prerelease: true
+          overwrite: true
+          body: |
+            ${{ env.PACKAGE_INFO_BODY }}

--- a/.github/workflows/snap_release.yaml
+++ b/.github/workflows/snap_release.yaml
@@ -1,8 +1,7 @@
 on:
   release:
     types:
-      - prereleased
-      - released
+      - published
   workflow_dispatch:
     inputs:
       upload_artifact:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
-# icon release
+# ICON release
+This repository to release packages of ICON projects that [loopchain], [icon-service], [icon-rpc-server]
 
 ## wheel build and github release
 ### run manual workflow
- - go to action page([release package action])
- - select Run workflow
- - input tags of repositories(loopchain, iconrpcserver, iconservice, rewardcalculator) and release tag
- - select Run workflow
+ - [release package action]
 
 ## snap build
-> TODO
+### run manual workflow
+ - [snap release action]
+
+### automation
+> automation build will be triggered when published on github release
 
 ## docker build
 > TODO
 
 
+[loopchain]: https://github.com/icon-project/loopchain
+[icon-service]: https://github.com/icon-project/icon-service
+[icon-rpc-server]: https://github.com/icon-project/icon-rpc-server
 [release package action]: https://github.com/icon-project/icon-release/actions?query=workflow%3A.github%2Fworkflows%2Frelease_packages.yaml
+[snap release action]: https://github.com/icon-project/icon-release/actions?query=workflow%3A.github%2Fworkflows%2Fsnap_release.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,13 +22,10 @@ parts:
     go-importpath: github.com/icon-project/rewardcalculator
     source: https://github.com/icon-project/rewardcalculator.git
     source-type: git
-    source-branch: master
     override-pull: |
       snapcraftctl pull
-      # /bin/bash $HOME/snap_build/rc_checkout_branch.sh
       # RC_LATEST_TAG=git describe --tags --abbrev=0
       LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
-      echo "rc tag : ${LATEST_TAG}"
       git checkout ${LATEST_TAG}
     override-build: |
       make
@@ -78,18 +75,34 @@ parts:
       - automake
       - pkg-config
       - libtool
-  loopchain:
+  iconrpcserver:
     after: [ install-dependency ]
     plugin: python
     python-version: python3
-    requirements:
-      - /root/snap_build/requirements_snap.txt
     source-type: git
-    source-branch: master
+    source: https://github.com/icon-project/icon-rpc-server.git
+    override-pull: |
+      snapcraftctl pull
+      LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+      git checkout ${LATEST_TAG}
+  iconservice:
+    after: [ iconrpcserver ]
+    plugin: python
+    python-version: python3
+    source-type: git
+    source: https://github.com/icon-project/icon-service.git
+    override-pull: |
+      snapcraftctl pull
+      LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+      git checkout ${LATEST_TAG}
+  loopchain:
+    after: [ iconservice ]
+    plugin: python
+    python-version: python3
+    source-type: git
     source: https://github.com/icon-project/loopchain.git
     override-pull: |
       snapcraftctl pull
-      # /bin/bash $HOME/snap_build/checkout_branch.sh
       LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
       git checkout ${LATEST_TAG}
       snapcraftctl set-version $(cat VERSION)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,138 @@
+name: loopchain
+type: app
+adopt-info: loopchain
+summary: loopchain citizen
+description: |
+  loopchain-citizen is software that loopchain client excluded vote function.
+confinement: strict
+base: core18
+
+parts:
+  snapcraft-preload:
+    source: https://github.com/diddledan/snapcraft-preload.git
+    source-type: git
+    source-branch: semaphore-support
+    plugin: cmake
+    build-packages:
+      - on amd64:
+        - gcc-multilib
+        - g++-multilib
+  icon-rc:
+    plugin: go
+    go-importpath: github.com/icon-project/rewardcalculator
+    source: https://github.com/icon-project/rewardcalculator.git
+    source-type: git
+    source-branch: master
+    override-pull: |
+      snapcraftctl pull
+      # /bin/bash $HOME/snap_build/rc_checkout_branch.sh
+      echo "release tag : ${RELEASE_TAG}"
+      echo "rc branch : ${RC_BRANCH}"
+      git checkout ${RC_BRANCH}
+    override-build: |
+      make
+      install -m 755 -D -t $SNAPCRAFT_PART_INSTALL/bin/ $SNAPCRAFT_PART_BUILD/bin/*
+    stage:
+      - bin/icon_rc
+      - bin/rctool
+  python3:
+    after: [ snapcraft-preload ]
+    source: https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz
+    source-type: tar
+    source-checksum: md5/389d3ed26b4d97c741d9e5423da1f43b
+    plugin: autotools
+    configflags: [--prefix=/usr]
+    build-packages:
+      - libssl1.0-dev
+      - libsqlite3-dev
+      - libbz2-dev
+      - liblzma-dev
+      - libdb-dev
+      - libgdbm-dev
+      - libreadline-dev
+      - zlib1g-dev
+      - libffi-dev
+    stage-packages:
+      - lsof
+      - net-tools
+    stage:
+      - -bin/netstat
+      - -sbin/ipmaddr
+      - -sbin/iptunnel
+      - -sbin/mii-tool
+      - -sbin/nameif
+      - -sbin/plipconfig
+      - -sbin/rarp
+      - -sbin/route
+      - -sbin/slattach
+      - -usr/sbin/arp
+      - -usr/lib/python3.7/test
+  install-dependency:
+    after: [ python3 ]
+    plugin: python
+    python-version: python3
+    python-packages:
+      - idna==2.7
+    build-packages:
+      - automake
+      - pkg-config
+      - libtool
+  loopchain:
+    after: [ install-dependency ]
+    plugin: python
+    python-version: python3
+    requirements:
+      - /root/snap_build/requirements_snap.txt
+    source-type: git
+    source-branch: master
+    source: https://github.com/icon-project/loopchain.git
+    override-pull: |
+      snapcraftctl pull
+      /bin/bash $HOME/snap_build/checkout_branch.sh
+      snapcraftctl set-version $(cat VERSION)
+      snapcraftctl set-grade stable
+    override-build: |
+      snapcraftctl build
+      cat > $SNAPCRAFT_PART_INSTALL/bin/init.sh <<EOF
+      #!/bin/bash
+      TARGET_DIR=\$1
+      if [ -z \$TARGET_DIR ]; then
+        TARGET_DIR=\$SNAP_USER_COMMON
+      fi
+      echo "copy default config files to \$TARGET_DIR"
+      cp -a \$SNAP/conf \$SNAP/scripts/* \$TARGET_DIR/
+      EOF
+      chmod +x $SNAPCRAFT_PART_INSTALL/bin/init.sh
+    override-stage: |
+      snapcraftctl stage
+    stage-packages:
+      - python-six
+    stage:
+      - -usr/bin/*
+      - -usr/share/*python*
+      - -usr/lib/python3.6
+
+apps:
+  loopchain:
+    command: bin/snapcraft-preload $SNAP/bin/loopchain
+    plugs:
+      - home
+      - network
+      - network-bind
+      - removable-media
+  init:
+    command: bin/init.sh
+    plugs:
+      - home
+  iconrpcserver:
+    command: bin/snapcraft-preload $SNAP/bin/iconrpcserver
+    plugs:
+      - home
+      - network
+      - network-bind
+  iconservice:
+    command: bin/snapcraft-preload $SNAP/bin/iconservice
+    plugs:
+      - home
+      - network
+      - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,9 +26,10 @@ parts:
     override-pull: |
       snapcraftctl pull
       # /bin/bash $HOME/snap_build/rc_checkout_branch.sh
-      echo "release tag : ${RELEASE_TAG}"
-      echo "rc branch : ${RC_BRANCH}"
-      git checkout ${RC_BRANCH}
+      # RC_LATEST_TAG=git describe --tags --abbrev=0
+      LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+      echo "rc tag : ${LATEST_TAG}"
+      git checkout ${LATEST_TAG}
     override-build: |
       make
       install -m 755 -D -t $SNAPCRAFT_PART_INSTALL/bin/ $SNAPCRAFT_PART_BUILD/bin/*
@@ -88,7 +89,9 @@ parts:
     source: https://github.com/icon-project/loopchain.git
     override-pull: |
       snapcraftctl pull
-      /bin/bash $HOME/snap_build/checkout_branch.sh
+      # /bin/bash $HOME/snap_build/checkout_branch.sh
+      LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+      git checkout ${LATEST_TAG}
       snapcraftctl set-version $(cat VERSION)
       snapcraftctl set-grade stable
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,12 +19,13 @@ parts:
         - g++-multilib
   icon-rc:
     plugin: go
+    go-channel: 1.12/stable
     go-importpath: github.com/icon-project/rewardcalculator
     source: https://github.com/icon-project/rewardcalculator.git
     source-type: git
     override-pull: |
       snapcraftctl pull
-      # RC_LATEST_TAG=git describe --tags --abbrev=0
+      go version
       LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
       git checkout ${LATEST_TAG}
     override-build: |
@@ -75,6 +76,8 @@ parts:
       - automake
       - pkg-config
       - libtool
+      - curl
+      - jq
   iconrpcserver:
     after: [ install-dependency ]
     plugin: python
@@ -105,7 +108,10 @@ parts:
       snapcraftctl pull
       LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
       git checkout ${LATEST_TAG}
-      snapcraftctl set-version $(cat VERSION)
+      VERSION=$(curl -H "Accept: application/vnd.github.v3+json" \
+        https://api.github.com/repos/icon-project/icon-release/releases/latest | jq -r .tag_name)
+      echo "release version : ${VERSION}"
+      snapcraftctl set-version ${VERSION}
       snapcraftctl set-grade stable
     override-build: |
       snapcraftctl build
@@ -119,8 +125,6 @@ parts:
       cp -a \$SNAP/conf \$SNAP/scripts/* \$TARGET_DIR/
       EOF
       chmod +x $SNAPCRAFT_PART_INSTALL/bin/init.sh
-    override-stage: |
-      snapcraftctl stage
     stage-packages:
       - python-six
     stage:


### PR DESCRIPTION
- snap build & release snap store
- snap release will be triggered when published github release
 [reference](https://github.community/t/actions-with-trigger-on-release-not-triggered-with-tags-created-by-automation/123038/3)

